### PR TITLE
Avoiding state pollution in `sns_event_raw`

### DIFF
--- a/tests/test_sns_event.py
+++ b/tests/test_sns_event.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 
 import pytest
@@ -42,7 +43,7 @@ def test_message_attributes(sns_event):
 
 
 def test_can_handle_missing_fields(sns_event_raw):
-    sns = sns_event_raw["Records"][0]["Sns"]
+    sns = copy.deepcopy(sns_event_raw["Records"][0]["Sns"])
     sns.pop("MessageAttributes")
     res = SnsMessage.from_json(sns)
     assert res.message_attributes is None


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_can_handle_missing_fields` by avoiding state pollution in `sns_event_raw` by making a deepcopy.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_commands.py::TestCommandDecorators::test_cmd_decorator`:

```
    def test_can_handle_missing_fields(sns_event_raw):
        sns = sns_event_raw["Records"][0]["Sns"]
>       sns.pop("MessageAttributes")
E       KeyError: 'MessageAttributes'
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
